### PR TITLE
Tim/reduce spam

### DIFF
--- a/vrpn_Connection.C
+++ b/vrpn_Connection.C
@@ -30,7 +30,8 @@
 static size_t MAX_SIZE_T = (size_t)(-1);
 
 // where to log
-#define ERR_FILE stderr
+// FILE *ERR_FILE = stderr; // Could also use any other file
+FILE *ERR_FILE = fopen("/tmp/vrpn.log", "w");
 
 #ifdef VRPN_USE_WINSOCK_SOCKETS
 


### PR DESCRIPTION
Changed all logs in `vrpn_connection.c` to `stderr` to logs to `/tmp/vrpn.log`. This was the file that created most of the spam.

Meaningful changes are in lines 33-35, everything else is a replacement of stderr with ERR_FILE or formatting